### PR TITLE
Fix for #1

### DIFF
--- a/dagens_ifi.py
+++ b/dagens_ifi.py
@@ -16,4 +16,5 @@ for day in menu:
     print ""
     print day["day_of_week"]
     for dish in day["dishes"]:
-        print "\t", dish["type"], "-", dish["name"]
+        line = "\t" + dish["type"] + "-" + dish["name"]
+        print line.encode("utf-8")

--- a/dagens_ifi.py
+++ b/dagens_ifi.py
@@ -13,8 +13,7 @@ print week["week_name"]
 print week["week_date"]
 
 for day in menu:
-    print ""
-    print day["day_of_week"]
+    print "\n" + day["day_of_week"]
     for dish in day["dishes"]:
-        line = "\t" + dish["type"] + "-" + dish["name"]
+        line = "\t" + dish["type"] + "\t- " + dish["name"]
         print line.encode("utf-8")


### PR DESCRIPTION
In addition to fixing unicode-bug I slightly changed the printed text to provide some space between the dash and the dish. Example:

```
Fredag
    Vegetar-Hamburgertallerken
    Vegetar-Risgrøt med saft
```

vs

```
Fredag
    Vegetar - Hamburgertallerken
    Vegetar - Risgrøt med saft
```
